### PR TITLE
fix: terra2 api

### DIFF
--- a/src/collector/collect.ts
+++ b/src/collector/collect.ts
@@ -18,7 +18,7 @@ export async function collect(
   tokenList: Record<string, boolean>
 ): Promise<void> {
   //latest Height or end Height
-  const latestBlock = await (chainId === 'columbus-4' ? columbus4EndHeight : lcd.getLatestBlockHeight().catch(errorHandler))
+  const latestBlock = chainId === 'columbus-4' ? columbus4EndHeight : await lcd.getLatestBlockHeight()
 
   if (!latestBlock) return
 

--- a/src/collector/main.ts
+++ b/src/collector/main.ts
@@ -17,9 +17,19 @@ async function loop(
   pairList: Record<string, boolean>,
   tokenList: Record<string, boolean>
 ): Promise<void> {
+  const MAX_EXPONENTIAL_FACTOR = 10
+  let delay = 500
+  let errCount = 0
   for (; ;) {
-    await collect(pairList, tokenList).catch(errorHandlerWithSentry)
-    await bluebird.delay(500)
+    try {
+      await collect(pairList, tokenList)
+      errCount = 0
+    } catch (err: any) {
+      errorHandlerWithSentry(err)
+      errCount = errCount + 1 > MAX_EXPONENTIAL_FACTOR ? 0 : errCount + 1
+    }
+    delay = delay * 2 ** errCount
+    await bluebird.delay(delay)
   }
 }
 

--- a/src/lib/terra/lcd/terra2.ts
+++ b/src/lib/terra/lcd/terra2.ts
@@ -14,14 +14,21 @@ export class Terra2Lcd implements Lcd {
         httpsAgent: new https.Agent({ keepAlive: true, maxTotalSockets: 5 }),
         timeout: 2 * 1000,
     })
-
-    async getLatestBlockHeight(): Promise<number> {
+    private async getLatestBlockHeightLegacy(): Promise<number> {
         try {
             const res = await this.client.get(`${this.lcdUrl}/blocks/latest`)
             return parseInt(res.data.block.header.height)
         } catch (err) {
-            console.log(err)
-            throw new Error(`cannot get latest block height`)
+            throw new Error(`latestBlockHeight: ${err}`)
+        }
+    }
+
+    async getLatestBlockHeight(): Promise<number> {
+        try {
+            const res = await this.client.get(`${this.lcdUrl}/cosmos/base/tendermint/v1beta1/blocks/latest`)
+            return parseInt(res.data.block.header.height)
+        } catch (err) {
+            return await this.getLatestBlockHeightLegacy()
         }
     }
     async getTokenInfo(address: string): Promise<TokenInfo> {


### PR DESCRIPTION
## Summary
- add an api path for the latest block with failover (cosmos LCD has been changed from the block `4711800`)