### PR TITLE
feat: divide wasm transfer mapper to support several types

### DIFF
--- a/src/collector/log-finder/nonnativeTransferLF.ts
+++ b/src/collector/log-finder/nonnativeTransferLF.ts
@@ -1,39 +1,83 @@
-import { createReturningLogFinder, ReturningLogFinderMapper } from '@terra-money/log-finder'
+import { Attributes, createReturningLogFinder, ReturningLogFinderMapper } from '@terra-money/log-finder'
 import { NonnativeTransferTransformed } from 'types'
 import logRules from './log-rules'
+import { num } from 'lib/num'
 
 export function createNonnativeTransferLogFinder(): ReturningLogFinderMapper<NonnativeTransferTransformed> {
   return createReturningLogFinder(logRules.nonnativeTransferRule(), (_, match) => {
     if (match[4]?.key === 'by') {
-      return {
-        addresses: {
-          from: match[2].value,
-          to: match[3].value,
-        },
-        assets: {
-          token: match[0].value,
-          amount: match[5].value,
-        },
-      }
+      return columbus4Mapper(match)
     }
-    const transformed = {
-      addresses: { from: "", to: "" },
-      assets: { token: "", amount: "" },
+
+    if (match[5]?.key === 'fee_amount') {
+      return tflokiMapper(match)
     }
-    match.forEach(m => {
-      if (m.key === "from") {
-        transformed.addresses.from = m.value
-      }
-      if (m.key === "to") {
-        transformed.addresses.to = m.value
-      }
-      if (m.key === "_contract_address" || m.key === "contract_address") {
-        transformed.assets.token = m.value
-      }
-      if (m.key === "amount") {
-        transformed.assets.amount = m.value
-      }
-    })
-    return transformed
+
+    return defaultMapper(match)
   })
+}
+
+function tflokiMapper(match: Attributes): NonnativeTransferTransformed {
+  const transformed = {
+    addresses: { from: "", to: "" },
+    assets: { token: "", amount: "" },
+  }
+  let feeAmount = "0";
+  match.forEach(m => {
+    if (m.key === "from") {
+      transformed.addresses.from = m.value
+    }
+    if (m.key === "to") {
+      transformed.addresses.to = m.value
+    }
+    if (m.key === "_contract_address" || m.key === "contract_address") {
+      transformed.assets.token = m.value
+    }
+    if (m.key === "amount") {
+      transformed.assets.amount = m.value
+    }
+    if (m.key === "fee_amount") {
+      feeAmount = m.value
+    }
+  })
+  transformed.assets.amount = num(transformed.assets.amount).minus(num(feeAmount)).toString()
+  return transformed
+}
+
+
+
+function defaultMapper(match: Attributes): NonnativeTransferTransformed {
+  const transformed = {
+    addresses: { from: "", to: "" },
+    assets: { token: "", amount: "" },
+  }
+  match.forEach(m => {
+    if (m.key === "from") {
+      transformed.addresses.from = m.value
+    }
+    if (m.key === "to") {
+      transformed.addresses.to = m.value
+    }
+    if (m.key === "_contract_address" || m.key === "contract_address") {
+      transformed.assets.token = m.value
+    }
+    if (m.key === "amount") {
+      transformed.assets.amount = m.value
+    }
+  })
+  return transformed
+}
+
+function columbus4Mapper(match: Attributes): NonnativeTransferTransformed {
+  return {
+    addresses: {
+      from: match[2].value,
+      to: match[3].value,
+    },
+    assets: {
+      token: match[0].value,
+      amount: match[5].value,
+    },
+  }
+
 }


### PR DESCRIPTION
## Background
- TFLOKI has different format of send
```
_contract_address terra1564y9uxzhast8sk5n47teypy4mxy7fg5vne2msuztsft7qk3pj9sxxuxmc
action send
from terra10mlyh4ygfrr0ltp93s9jrjlxqfkw4q8snzxv28
to terra1qe36wap4lrwx4yanhvst33lvvxfdryve8c6uwhvks36p07z5qvlq0cx202
amount 10000000000
fee_amount 10000000
```