### PR TITLE
Apply specific rules for classic pairs(`terra15ukfg2wy9xd4g8hd5nl2rdyn7arlwk4l9u6kalwmg0pew5pjlpgskydg2a`, `terra1anwgp97zfn6zsz9t5vgtan4s09n24khx0twu3a550m4dsxj699pq8mg5yz`)

### DIFF
--- a/src/collector/log-finder/nonnativeTransferLF.ts
+++ b/src/collector/log-finder/nonnativeTransferLF.ts
@@ -3,7 +3,7 @@ import { NonnativeTransferTransformed } from 'types'
 import logRules from './log-rules'
 import { num } from 'lib/num'
 import { isClassic, isColumbus4 } from 'lib/terra'
-import { ClassicFeeAppliedTokenSet } from 'lib/terraswap/classic.consts'
+import { ClassicReceiverFeeAppliedTokenSet, ClassicReceiverFeeAppliedPairSet } from 'lib/terraswap/classic.consts'
 
 
 const FEE_AMOUNT_KEY = 'fee_amount'
@@ -31,8 +31,9 @@ function createCol4LogFinder(height?: number) {
 function createClassicLogFinder(height?: number) {
   return createReturningLogFinder(logRules.nonnativeTransferRule(height), (_, match) => {
     const transformed = feeApplyMapper(match)
-    if (ClassicFeeAppliedTokenSet.has(transformed.assets.token)) {
-      // already applied, rollback
+    if (ClassicReceiverFeeAppliedTokenSet.has(transformed.assets.token) &&
+      // if ReceiverFeeAppliedToken is transferred from the pair, the amount need to be adjusted
+      ClassicReceiverFeeAppliedPairSet.has(transformed.addresses.from)) {
       const feeAmount = match.find(m => m.key === FEE_AMOUNT_KEY || m.key === TAX_AMOUNT_KEY || m.key === CW20_TAX_AMOUNT_KEY)?.value || "0"
       transformed.assets.amount = num(transformed.assets.amount).plus(num(feeAmount)).toString()
     }

--- a/src/lib/terraswap/classic.consts.ts
+++ b/src/lib/terraswap/classic.consts.ts
@@ -1,4 +1,9 @@
-export const ClassicFeeAppliedTokenSet: Set<string> = new Set([
-    "terra1zkhwtm4a559emekwj7z4vklzqupgjyad8ncpwvav38y5ef6g5tjse7ceus",
-    "terra1naaldj58aerjvqzulrnfpeph60pjqlyp60gqryup8g4djy4cn4nqwm08c3"
+export const ClassicReceiverFeeAppliedTokenSet: Set<string> = new Set([
+"terra1zkhwtm4a559emekwj7z4vklzqupgjyad8ncpwvav38y5ef6g5tjse7ceus",
+"terra1naaldj58aerjvqzulrnfpeph60pjqlyp60gqryup8g4djy4cn4nqwm08c3"
+])
+
+export const ClassicReceiverFeeAppliedPairSet: Set<string> = new Set([
+    "terra15ukfg2wy9xd4g8hd5nl2rdyn7arlwk4l9u6kalwmg0pew5pjlpgskydg2a",
+    "terra1anwgp97zfn6zsz9t5vgtan4s09n24khx0twu3a550m4dsxj699pq8mg5yz"
 ])


### PR DESCRIPTION
## Background
- TerraSwap uses cw20.Send but some tokens have tax on the receiver side.
- except `withdraw`, the amount of (`swap`, `provide`) need to be deducted `tax amount`
