### PR TITLE
Remove `provide_liquidity` condition from initial_provide search

### DIFF
--- a/src/collector/indexer/index.ts
+++ b/src/collector/indexer/index.ts
@@ -48,13 +48,11 @@ export async function runIndexers(
           // txHistory
           const spwfLF = createSPWFinder(pairList, height)
           const spwfLogFounds = spwfLF(event)
- 
+
+          const ipLogFounds = createInitialProvideFinder(pairList)(event).filter(ip => ip.transformed)
+          await InitialProvideIndexer(manager, ipLogFounds)
+
           if (spwfLogFounds.length > 0) {
-            // initial provide 
-            if (spwfLogFounds.find((logFound) => logFound.transformed?.action === 'provide_liquidity')) {
-              const ipLogFounds = createInitialProvideFinder(pairList)(event).filter(ip=> ip.transformed)
-              await InitialProvideIndexer(manager, ipLogFounds)
-            }
             await TxHistoryIndexer(manager, exchangeRate, timestamp, txHash, spwfLogFounds)
           }
 


### PR DESCRIPTION
## Background
`wasm` event_log used to be one message and included all the contracts' messages.
But, it has been changed on Terra mainnet(`phoenix`)
