### PR TITLE
Limit BASE token fee applied pair

### DIFF
--- a/src/collector/log-finder/nonnativeTransferLF.ts
+++ b/src/collector/log-finder/nonnativeTransferLF.ts
@@ -40,6 +40,7 @@ function createClassicLogFinder(height?: number) {
 
     const oddTokenHandlingInfo = ClassicOddTokenHandlerMap.get(transformed.assets.token)
     if (
+      oddTokenHandlingInfo?.pair(transformed.addresses.to) &&
       oddTokenHandlingInfo?.action(match?.find(m => m.key === "action")?.value) &&
       height && height >= oddTokenHandlingInfo?.appliedHeight
     ) {

--- a/src/lib/terraswap/classic.consts.ts
+++ b/src/lib/terraswap/classic.consts.ts
@@ -12,13 +12,19 @@ export const ClassicReceiverFeeAppliedPairSet: Set<string> = new Set([
 interface OddTokenHandlingInfo {
     feeRate: string
     appliedHeight: number
-    action: (a: string)=> boolean
+    action: (a: string) => boolean
+    pair: (p: string) => boolean
 }
+
+const oddTokenAppliedPair: Set<string> = new Set([
+    "terra1ggjadsdn285f4ae9wykle5lnawna7gdk32g6dfgpev8j0hx5jkpsc7u4gn", // uluna - BASE
+])
 
 const CLASSIC_BASE_TOKEN = "terra1uewxz67jhhhs2tj97pfm2egtk7zqxuhenm4y4m"
 const APPLIED_HEIGHT = 16746830
 export const ClassicOddTokenHandlerMap: Map<string, OddTokenHandlingInfo> = new Map([[CLASSIC_BASE_TOKEN, {
     feeRate: "0.048",
     appliedHeight: APPLIED_HEIGHT,
-    action: (a: string) => a === "send"
+    action: (a: string) => a === "send",
+    pair: (p: string) => oddTokenAppliedPair.has(p)
 }]])


### PR DESCRIPTION
## Background
- BASE token(`terra1uewxz67jhhhs2tj97pfm2egtk7zqxuhenm4y4m`) has 4.8% fee for `send`

## Problem
-  pair `terra1kaphd3s9kl72cht3qmn0elkcqezcz60zarapah677adg8dhtvlequ6gezy` has BASE token but it doesn't have 4.8% tax

## Solution
- limit the fee apply logic to specific pair
