### PR TITLE
Skip BASE-uluna validation

### DIFF
--- a/src/collector/indexer/common.ts
+++ b/src/collector/indexer/common.ts
@@ -6,6 +6,7 @@ import { PairDataEntity, PairDayDataEntity, PairHourDataEntity, PairInfoEntity, 
 import { ExchangeRate } from 'types'
 import { num } from 'lib/num'
 import { lcd } from 'lib/terra/lcd'
+import { ClassicOddTokenAppliedPair } from 'lib/terraswap/classic.consts'
 
 // get token's UST price from token-UST pair that have the largest liquidity
 export async function getTokenPriceAsUST(
@@ -171,6 +172,9 @@ export async function comparePairReserve(height: number, em: EntityManager): Pro
 
   const compare = async (pds: PairDataEntity[]) => {
     const pdPromises = pds.map(async (pd) => {
+      if (validationExceptionSet.has(pd.pair)) {
+        return
+      }
       let poolInfo;
       try {
         poolInfo = await lcd.getPoolInfo(pd.pair, height)
@@ -240,6 +244,8 @@ export async function getTokenList(manager: EntityManager): Promise<Record<strin
 
   return tokenList
 }
+
+const validationExceptionSet: Set<string> = new Set(ClassicOddTokenAppliedPair)
 
 interface Asset {
   token: string

--- a/src/lib/terraswap/classic.consts.ts
+++ b/src/lib/terraswap/classic.consts.ts
@@ -16,7 +16,7 @@ interface OddTokenHandlingInfo {
     pair: (p: string) => boolean
 }
 
-const oddTokenAppliedPair: Set<string> = new Set([
+export const ClassicOddTokenAppliedPair: Set<string> = new Set([
     "terra1ggjadsdn285f4ae9wykle5lnawna7gdk32g6dfgpev8j0hx5jkpsc7u4gn", // uluna - BASE
 ])
 
@@ -26,5 +26,5 @@ export const ClassicOddTokenHandlerMap: Map<string, OddTokenHandlingInfo> = new 
     feeRate: "0.048",
     appliedHeight: APPLIED_HEIGHT,
     action: (a: string) => a === "send",
-    pair: (p: string) => oddTokenAppliedPair.has(p)
+    pair: (p: string) => ClassicOddTokenAppliedPair.has(p)
 }]])


### PR DESCRIPTION
## Background
- BASE token has a customized mechanism
- cannot track by `wasm` message 

## Solution
- skip the pool amount validation